### PR TITLE
Channel 0 is centered at DC, not CHAN_BW/2

### DIFF
--- a/mnc/common.py
+++ b/mnc/common.py
@@ -133,7 +133,7 @@ def chan_to_freq(chan):
     Convert a channel number to a frequency in Hz.
     """
     
-    return CHAN_BW*(chan + 0.5)
+    return CHAN_BW*chan
 
 
 def freq_to_chan(freq):
@@ -141,7 +141,7 @@ def freq_to_chan(freq):
     Convert a frequency in Hz to a channel number.
     """
     
-    return int(freq / CHAN_BW + 0.5)
+    return int(round(freq / CHAN_BW))
 
 
 def quota_size(value):


### PR DESCRIPTION
This PR updates the `common.chan_to_freq` and `common.freq_to_chan` functions to match what @realtimeradio says they should be.