### PR TITLE
Implement status xengine

### DIFF
--- a/mnc/control.py
+++ b/mnc/control.py
@@ -5,6 +5,7 @@ import numpy as np
 import glob
 from dsautils import dsa_store
 from lwautils import lwa_arx   # arx
+import time
 
 from mnc.common import get_logger
 logger = get_logger(__name__)
@@ -306,9 +307,13 @@ class Controller():
     def status_xengine(self):
         """ to be implemented for more detailed monitor point info
         """
-        print("Pipeline id: connection, up")
+        AGE_THRESHOLD_S = 10
+        print("Pipeline id: alive capture_gbps corr_gbps")
         for pipeline in self.pipelines:
-            print(f'{pipeline.pipeline_id}: {pipeline.check_connection()}, {pipeline.pipeline_is_up()}')
+            capture_status = pipeline.capture.get_bifrost_status()
+            corr_status = pipeline.corr.get_bifrost_status()
+            alive = (time.time() - corr_status['time'] < AGE_THRESHOLD_S)
+            print(f"{pipeline.host}:{pipeline.pipeline_id}:\t{alive}\t{capture_status['gbps']:.1f}\t{corr_status['gbps']:.1f}")
 
     def stop_xengine(self):
         """ Stop xengines listed in configuration file.

--- a/mnc/control.py
+++ b/mnc/control.py
@@ -317,7 +317,7 @@ class Controller():
                 raise RuntimeError("Failed to get X engine capture block status.")
             alive = (time.time() - corr_status['time'] < AGE_THRESHOLD_S)
             print(fmt.format(f'{pipeline.host}:{pipeline.pipeline_id}',
-                             alive,
+                             str(bool(alive)),
                              f"{capture_status['gbps']:1.f}",
                              f"{corr_status['gbps']:1.f}"))
 

--- a/mnc/control.py
+++ b/mnc/control.py
@@ -305,15 +305,21 @@ class Controller():
             logging.info('Not tracking')
 
     def status_xengine(self):
-        """ to be implemented for more detailed monitor point info
+        """ print x engine status
         """
         AGE_THRESHOLD_S = 10
-        print("Pipeline id: alive capture_gbps corr_gbps")
+        fmt = '{<16}{<8}{<14}{<14}'
+        print(fmt.format("Pipeline id:", "alive", "capture_gbps", "corr_gbps"))
         for pipeline in self.pipelines:
             capture_status = pipeline.capture.get_bifrost_status()
             corr_status = pipeline.corr.get_bifrost_status()
+            if capture_status is None:
+                raise RuntimeError("Failed to get X engine capture block status.")
             alive = (time.time() - corr_status['time'] < AGE_THRESHOLD_S)
-            print(f"{pipeline.host}:{pipeline.pipeline_id}:\t{alive}\t{capture_status['gbps']:.1f}\t{corr_status['gbps']:.1f}")
+            print(fmt.format('pipeline.host:{pipeline.pipeline_id}',
+                             alive,
+                             f"{capture_status['gbps']:1.f}",
+                             f"{corr_status['gbps']:.1f}"))
 
     def stop_xengine(self):
         """ Stop xengines listed in configuration file.

--- a/mnc/control.py
+++ b/mnc/control.py
@@ -318,8 +318,8 @@ class Controller():
             alive = (time.time() - corr_status['time'] < AGE_THRESHOLD_S)
             print(fmt.format(f'{pipeline.host}:{pipeline.pipeline_id}',
                              str(bool(alive)),
-                             f"{capture_status['gbps']:1.f}",
-                             f"{corr_status['gbps']:1.f}"))
+                             f"{capture_status['gbps']:.1f}",
+                             f"{corr_status['gbps']:.1f}"))
 
     def stop_xengine(self):
         """ Stop xengines listed in configuration file.

--- a/mnc/control.py
+++ b/mnc/control.py
@@ -308,7 +308,7 @@ class Controller():
         """ print x engine status
         """
         AGE_THRESHOLD_S = 10
-        fmt = '{<16}{<8}{<14}{<14}'
+        fmt = '{:<16}{:<8}{:<14}{:<14}'
         print(fmt.format("Pipeline id:", "alive", "capture_gbps", "corr_gbps"))
         for pipeline in self.pipelines:
             capture_status = pipeline.capture.get_bifrost_status()
@@ -316,10 +316,10 @@ class Controller():
             if capture_status is None:
                 raise RuntimeError("Failed to get X engine capture block status.")
             alive = (time.time() - corr_status['time'] < AGE_THRESHOLD_S)
-            print(fmt.format('pipeline.host:{pipeline.pipeline_id}',
+            print(fmt.format(f'{pipeline.host}:{pipeline.pipeline_id}',
                              alive,
                              f"{capture_status['gbps']:1.f}",
-                             f"{corr_status['gbps']:.1f}"))
+                             f"{corr_status['gbps']:1.f}"))
 
     def stop_xengine(self):
         """ Stop xengines listed in configuration file.


### PR DESCRIPTION
implemented `stauts_xengine()` to print whether processes are alive and capture block's and corr block's throughput. Intention is that this is a go/no-go prototype for the xengine. Hopefully the throughput tells people when the correlator is not getting anything from the f engine.
Questions
- Other essential things I should check? Should I poll it twice and calculate real-time loss fraction, late, missing?
- I know this duplicates some of what you have in the correlator control code...let me know if it's better for some of this to live elsewhere

TODOs:
- time to refactor out a thing that throws an exception whenever get_bifrost_status gives None.
- This should return a data structure, rather than print, so that someone can use this for the dashboard.

```
In [2]: con = control.Controller(f"/home/pipeline/proj/lwa-shell/mnc_python/config/lwa_config_calim.yaml
   ...: ")
2023-02-17 19:08:12,484 - mnc.control - INFO - Loaded configuration for 8 x-engine host(s) running 4 pipeline(s) each
2023-02-17 19:08:12,484 - mnc.control - INFO - Supported recorder modes are: slow,beam1,beam2,beam3,beam4
2023-02-17 19:08:12,484 - mnc.control - INFO - etcd server being used is: etcdv3service

In [3]: con.status_xengine()
Pipeline id: alive capture_gbps corr_gbps
lxdlwagpu01:0:	True	0.0	48.1
lxdlwagpu01:1:	True	0.0	125.0
lxdlwagpu01:2:	True	0.0	52.3
lxdlwagpu01:3:	True	0.0	43.5
lxdlwagpu02:0:	True	0.0	33.2
lxdlwagpu02:1:	True	0.0	25.5
lxdlwagpu02:2:	True	0.0	19.7
lxdlwagpu02:3:	True	0.0	24.8
lxdlwagpu03:0:	True	0.0	41.7
lxdlwagpu03:1:	True	0.0	89.8
lxdlwagpu03:2:	True	0.0	59.5
lxdlwagpu03:3:	True	0.0	25.7
lxdlwagpu04:0:	True	0.0	91.6
lxdlwagpu04:1:	True	0.0	41.6
lxdlwagpu04:2:	True	0.0	37.4
lxdlwagpu04:3:	True	0.0	41.5
lxdlwagpu05:0:	True	0.0	25.0
lxdlwagpu05:1:	True	0.0	49.2
lxdlwagpu05:2:	True	0.0	105.5
lxdlwagpu05:3:	True	0.0	120.2
lxdlwagpu06:0:	True	0.0	26.5
lxdlwagpu06:1:	True	0.0	51.6
lxdlwagpu06:2:	True	0.0	36.4
lxdlwagpu06:3:	True	0.0	49.3
lxdlwagpu07:0:	True	0.0	31.0
lxdlwagpu07:1:	True	0.0	163.6
lxdlwagpu07:2:	True	0.0	48.3
lxdlwagpu07:3:	True	0.0	64.6
lxdlwagpu08:0:	True	0.0	44.4
lxdlwagpu08:1:	True	0.0	49.1
lxdlwagpu08:2:	True	0.0	42.0
lxdlwagpu08:3:	True	0.0	28.9
```