### PR TITLE
Add Fast visibility selection by LWA antenna name

### DIFF
--- a/config/lwa_config_calim_interleave.yaml
+++ b/config/lwa_config_calim_interleave.yaml
@@ -150,6 +150,56 @@ xengines:
   x_dest_beam_port: [20001, 20002, 20001, 20002, 20001, 20002, 20001, 20002]
   cal_directory: "/home/pipeline/caltables/latest/"   # location on destination server of calibration tables
   update_interval: 15  # beamformer tracking update cadence in seconds
+  # Which antennas to output in the fast dump stream
+  fast_vis_ants:
+    - LWA-007
+    - LWA-021
+    - LWA-025
+    - LWA-029
+    - LWA-033
+    - LWA-063
+    - LWA-064
+    - LWA-065
+    - LWA-096
+    - LWA-097
+    - LWA-129
+    - LWA-160
+    - LWA-161
+    - LWA-193
+    - LWA-195
+    - LWA-223
+    - LWA-225
+    - LWA-226
+    - LWA-245
+    - LWA-252
+    - LWA-253
+    - LWA-254
+    - LWA-255
+    - LWA-256
+    - LWA-275
+    - LWA-279
+    - LWA-286
+    - LWA-287
+    - LWA-290
+    - LWA-293
+    - LWA-316
+    - LWA-322
+    - LWA-325
+    - LWA-326
+    - LWA-328
+    - LWA-329
+    - LWA-333
+    - LWA-334
+    - LWA-345
+    - LWA-347
+    - LWA-348
+    - LWA-353
+    - LWA-355
+    - LWA-357
+    - LWA-358
+    - LWA-359
+    - LWA-361
+    - LWA-363
 
 # IP address of each data recorder server (used by x-eng control)
 drip_mapping:
@@ -167,4 +217,4 @@ drip_mapping:
 
 # Data recorder configuration
 dr:
-        recorders: ['drvs', 'dr1', 'dr2', 'dr3', 'dr4']  # Supported modes "drvs" (slow vis), "drvf" (fast vis), "dr1" up to 8 (power beam)
+        recorders: ['drvs', 'drvf', 'dr1', 'dr2', 'dr3', 'dr4']  # Supported modes "drvs" (slow vis), "drvf" (fast vis), "dr1" up to 8 (power beam)


### PR DESCRIPTION
- Add `fast_vis_ants` config file field, which should contain a list of LWA names
- When fast visibility recording is enabled update all pipelines with selected antennas
- Update default configuration file to enable fast visibilities for DG's suggested antennas