### PR TITLE
Pass flags and weights for beams.

### DIFF
--- a/mnc/control.py
+++ b/mnc/control.py
@@ -1,6 +1,7 @@
 import os.path
 import yaml
 import logging
+from typing import Union, Callable, List
 import glob
 import numpy as np
 import glob
@@ -27,6 +28,8 @@ from mnc import mcs, xengine_beamformer_control
 
 CONFIG_FILE = '/home/pipeline/proj/lwa-shell/mnc_python/config/lwa_config_calim.yaml'
 FPG_FILE = '/home/ubuntu/proj/lwa-shell/caltech-lwa/snap2_f_200msps_64i_4096c/outputs/snap2_f_200msps_64i_4096c.fpg'
+
+CORE_RADIUS_M = 200.0
 
 class Controller():
     """ Parse configuration and control all subsystems in uniform manner.
@@ -310,12 +313,14 @@ class Controller():
 
 
     def control_bf(self, num=1, coord=None, coordtype='celestial', targetname=None,
-                   track=True, beam_gain=None, duration=0):
+                   track=True, weight: Union[str, Callable[[float], float]]='core',
+                   beam_gain=None, duration=0):
         """ Point and track beamformers.
         num refers to the beamformer number (1 through 8).
         If track=True, target is treated as celestial coords or by target name
         If track=False, target is treated as (az, el)
-        beam_gain optionally specifies the gain for the beam.
+        weight can be: 'core', 'natural', a single antenna name, or a function (see xengine_beamformer_control.set_beam_weights)
+        beam_gain optionally specifies the amplitude scaling for the beam.
         duration is time to track in seconds (0 means 12 hrs).
         target can be:
          - source name ('zenith', 'sun') or
@@ -339,6 +344,18 @@ class Controller():
             msg = "Xengine not configured for beam {num}"
             logger.error(msg)
             raise KeyError(msg)
+
+        if (callable(weight)):
+            assert weight.__code__.co_argcount == 1, "weight function must only take one argument"
+            self.bfc[num].set_beam_weighting(weight)
+        elif (weight == 'core'):
+            self.bfc[num].set_beam_weighting(_core_weight_func)
+        elif (weight == 'natural'):
+            pass
+        elif weight.startswith('LWA-'):
+            self.bfc[num].set_beam_weighting(flag_ants=_single_ant_flags_list(weight))
+        else:
+            raise ValueError(f'Invalid value for weight {weight}')
 
         if beam_gain:
             self.bfc[num].set_beam_gain(beam_gain)
@@ -525,3 +542,11 @@ class Controller():
                 logger.info(f"recording on {recorder} stopped")
             else:
                 logger.warn(f"stopping recording on {recorder} failed: {response['response']}")
+
+def _core_weight_func(r: float) -> float:
+    return 1.0 if r < CORE_RADIUS_M else 0.0
+
+def _single_ant_flags_list(antname: str) -> List[int]:
+    flag_list = list(range(352))
+    flag_list.remove(mapping.antname_to_correlator(antname))
+    return flag_list


### PR DESCRIPTION
Ref issues https://github.com/ovro-lwa/lwa-issues/issues/433 https://github.com/ovro-lwa/lwa-issues/issues/382.

Hopefully this reduces the number of caltables and config files floating around (only need daytime/nighttime setting calib files).

could use some comments on the interface. I can add another flag_list argument to `control_bf` for flagging additional antennas if need be.

This allows single antenna beamforming and core-only beam forming to not need separate cal tables.

looks reasonable but I haven't tested it end-to-end.
```
In [1]: from mnc.control import Controller
Read antpos from xlsx file in repo

In [2]: con = Controller()
2023-06-25 23:31:42,378 - mnc.control - INFO - Loaded configuration for 8 x-engine host(s) running 4 pipeline(s) each
2023-06-25 23:31:42,378 - mnc.control - INFO - Supported recorder modes are: slow,fast,beam1
2023-06-25 23:31:42,378 - mnc.control - INFO - etcd server being used is: etcdv3service

In [3]: con.configure_xengine('dr1')
2023-06-25 23:32:57,400 - mnc.control - INFO - pipelines up? True
2023-06-25 23:32:57,400 - mnc.control - INFO - Not configuring x-engine for visibilities
2023-06-25 23:32:57,400 - mnc.control - INFO - Not configuring x-engine for fast visibilities
2023-06-25 23:32:57,400 - mnc.control - INFO - Configuring x-engine for beam 1 on xhosts ['lxdlwagpu01', 'lxdlwagpu02', 'lxdlwagpu03', 'lxdlwagpu04', 'lxdlwagpu05', 'lxdlwagpu06', 'lxdlwagpu07', 'lxdlwagpu08']
2023-06-25 23:32:58,478 - mnc.control - INFO - Done setting calibration gains for beam 1

In [4]: con.control_bf()
2023-06-25 23:34:00,316 - mnc.control - WARNING - Coordinates not fully specified. Pointing at zenith.
2023-06-25 23:34:00,439 - mnc.xengine_beamformer_control - WARNING - Calibration is not set, your results may be suspect
2023-06-25 23:34:00,970 - mnc.control - INFO - beam 1 calibration not set
2023-06-25 23:34:00,970 - root - INFO - Beam 1: Not tracking for azel input

In [5]: con.control_bf(weight='LWA-244')
2023-06-25 23:34:17,525 - mnc.control - WARNING - Coordinates not fully specified. Pointing at zenith.
2023-06-25 23:34:17,530 - mnc.xengine_beamformer_control - WARNING - Calibration is not set, your results may be suspect
2023-06-25 23:34:18,083 - mnc.control - INFO - beam 1 calibration not set
2023-06-25 23:34:18,083 - root - INFO - Beam 1: Not tracking for azel input

In [6]: con.bfc[1]
Out[6]: <xengine_beamformer_control.BeamPointingControl beam=1>

In [7]: con.bfc[1]._weights
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-7-619dedddd498> in <module>()
----> 1 con.bfc[1]._weights

AttributeError: 'BeamPointingControl' object has no attribute '_weights'

In [8]: con.bfc[1]._weighting
Out[8]: 
array([0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 1., 1., 0., 0.,
       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
       0., 0., 0., 0., 0., 0., 0.])

In [9]: con.control_bf(weight='core')
2023-06-25 23:36:08,224 - mnc.control - WARNING - Coordinates not fully specified. Pointing at zenith.
2023-06-25 23:36:08,347 - mnc.xengine_beamformer_control - WARNING - Calibration is not set, your results may be suspect
2023-06-25 23:36:08,908 - mnc.control - INFO - beam 1 calibration not set
2023-06-25 23:36:08,908 - root - INFO - Beam 1: Not tracking for azel input

In [10]: con.bfc[1]._weighting
Out[10]: 
array([0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
       0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0., 0.,
       0., 0., 0., 0., 0., 0., 0., 0., 0., 1., 1., 1., 1., 1., 1., 1., 1.,
       1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1.,
       1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1.,
       1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 0., 0., 1., 1., 0., 0., 0.,
       0., 0., 0., 0., 0., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1.,
       1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1.,
       1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1.,
       1., 1., 1., 1., 1., 1., 0., 0., 1., 1., 0., 0., 0., 0., 0., 0., 0.,
       0., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1.,
       1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1.,
       1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1.,
       1., 1., 0., 0., 0., 0., 0., 0., 0., 0., 1., 1., 0., 0., 1., 1., 1.,
       1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1.,
       1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1.,
       1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 0., 0.,
       1., 1., 1., 1., 0., 0., 0., 0., 0., 0., 1., 1., 1., 1., 1., 1., 1.,
       1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1.,
       1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1.,
       1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 0., 0.,
       1., 1., 0., 0., 0., 0., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1.,
       1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1.,
       1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1.,
       1., 1., 1., 1., 1., 1., 1., 0., 0., 0., 0., 1., 1., 0., 0., 0., 0.,
       0., 0., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1.,
       1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1.,
       1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1.,
       1., 1., 1., 0., 0., 0., 0., 1., 1., 0., 0., 0., 0., 0., 0., 1., 1.,
       1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1.,
       1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1.,
       1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 0.,
       0., 0., 0., 1., 1., 0., 0., 0., 0., 0., 0., 1., 1., 1., 1., 1., 1.,
       1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1.,
       1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1.,
       1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 0., 0., 0., 0., 0.,
       0., 0., 0., 0., 0., 1., 1.])
```