### PR TITLE
Bring back start_xengine

### DIFF
--- a/mnc/control.py
+++ b/mnc/control.py
@@ -340,7 +340,7 @@ class Controller():
                              f"{capture_status['gbps']:.1f}",
                              f"{corr_status['gbps']:.1f}"))
 
-    def start_xengine(self, timeout):
+    def start_xengine(self, timeout=300):
         if self.pcontroller.pipelines_are_up():
             msg = 'Pipelines are running. Please stop the xengine first.'
             logger.error(msg)


### PR DESCRIPTION
The current setup still breaks the correlator whenever someone runs `configure` with `drvs` after `drvf`. Since dr destinations and antenna selections don't really change, I'm lumping the data destination config into the `start_xengine()` method.

There shouldn't be a need to restart the xengine in most cases. Also helps with continuous operation for visibility buffer.

Will test this on Mon

...Next step is get rid of configure_xengine()