### PR TITLE
Set `BeamPointingControl.cal_state` based on X-engine status

### DIFF
--- a/mnc/xengine_beamformer_control.py
+++ b/mnc/xengine_beamformer_control.py
@@ -158,10 +158,10 @@ class BeamPointingControl(object):
         
         return all(self._cal_set)
         
-    def set_beam_dest(self, addr=None, port=None, addr_base='10.41.0.76', port_base=20001):
+    def set_beam_dest(self, addr=None, port=None, addr_base='10.41.0.97', port_base=20001):
         """
         Set the destination IP address and UDP port for the beam data.  Defaults
-        to what is currently used by the "dr-beam-N" services on lxdlwagpu09.
+        to what is currently used by the "dr-beam-N" services on lwateng.
         """
         
         # If an address is not explicitly provided, find what is should be using


### PR DESCRIPTION
This PR updates the `BeamPointingControl` class in `mnc.xengine_beamformer_control` to use the new X-engine `cal_gains#` state variable (see https://github.com/ovro-lwa/lwa-issues/issues/420) to set the initial `cal_set` value for a beam.  A beam is considered calibrated at initialization if more than 90% of the inputs (633) on every X-engine pipeline have a calibration gain set.