### PR TITLE
Small change to `mnc.mcs.Client` cleanup

### DIFF
--- a/mnc/mcs.py
+++ b/mnc/mcs.py
@@ -417,9 +417,12 @@ class Client(object):
         for command in self._watchers:
             try:
                 self.client.cancel_watch(self._watchers[command][0])
-                self.client.close()
             except Exception:
                 pass
+        try:
+            self.client.close()
+        except Exception:
+            pass
         
     def _update_mon_manifest(self, name, drop=False):
         """


### PR DESCRIPTION
This PR makes a change to the `__del__` method in `mnc.mcs.Client` so that it closes out as many watchers as possible before closing the etcd connection.