### PR TITLE
Set the beam calibration state using the X-engines - Proposal 2

### DIFF
--- a/mnc/xengine_beamformer_control.py
+++ b/mnc/xengine_beamformer_control.py
@@ -140,9 +140,13 @@ class BeamPointingControl(object):
             freq = chan_to_freq(metadata['chan0'] + numpy.arange(metadata['nchan']))
             self.freqs.append(freq)
             
-            cal_state = metadata['stats'][f"cal_gains{self.beam-1}"]
-            if isinstance(cal_state, str):
-                cal_state = [1 if f.find('True') != -1 else 0 for f in cal_state.split(',')]
+            cal_state0 = metadata['stats'][f"cal_gains{2*(self.beam-1)+0}"]
+            cal_state1 = metadata['stats'][f"cal_gains{2*(self.beam-1)+1}"]
+            if isinstance(cal_state0, str):
+                cal_state0 = [1 if f.find('True') != -1 else 0 for f in cal_state0.split(',')]
+            if isinstance(cal_state1, str):
+                cal_state1 = [1 if f.find('True') != -1 else 0 for f in cal_state1.split(',')]
+            cal_state = [s0 or s1 for s0,s1 in zip(cal_state0, cal_state1)]
             if sum(cal_state) >= NINPUT_CAL_FOR_GOOD:
                 self._cal_set.append(True)
             else:

--- a/mnc/xengine_beamformer_control.py
+++ b/mnc/xengine_beamformer_control.py
@@ -146,7 +146,7 @@ class BeamPointingControl(object):
                 cal_state0 = [1 if f.find('True') != -1 else 0 for f in cal_state0.split(',')]
             if isinstance(cal_state1, str):
                 cal_state1 = [1 if f.find('True') != -1 else 0 for f in cal_state1.split(',')]
-            cal_state = [s0 or s1 for s0,s1 in zip(cal_state0, cal_state1)]
+            cal_state = [s0 and s1 for s0,s1 in zip(cal_state0, cal_state1)]
             if sum(cal_state) >= NINPUT_CAL_FOR_GOOD:
                 self._cal_set.append(True)
             else:
@@ -307,7 +307,8 @@ class BeamPointingControl(object):
                     cal = numpy.where(numpy.isfinite(cal), cal, 0)
                     flg = flgdata[j,i*NCHAN_PIPELINE:(i+1)*NCHAN_PIPELINE,pol].ravel()
                     cal *= (1-flg)
-                    to_execute.append(push_gains(p, ii, 2*(self.beam-1)+pol, NPOL*j+pol, cal))
+                    to_execute.append(push_gains(p, ii, 2*(self.beam-1)+0, NPOL*j+pol, cal*(1-pol)))
+                    to_execute.append(push_gains(p, ii, 2*(self.beam-1)+1, NPOL*j+pol, cal*pol))
         loop.run_until_complete(asyncio.gather(*to_execute, loop=loop))
         loop.close()
     


### PR DESCRIPTION
This PR updates the way `xengine_beamformer_control.py` to use the X-engines "cal_gains#" state variables to set the beam calibration state.  This is one of two proposals.

## This Method
The PR uses an "and" of the single polarization X-engine beams to set the beam state.  Since "and" is used the calibration gain setting now needs to explicitly set all unused inputs to zero.

### Pros:
 * It will support other beam polarization schemes where stand pols. need to be mixed.

### Cons:
 * It requires twice as many calibration gain commands to be sent to the X-engine pipelines for the (currently) unused inputs in each single pol. X-engine beam.
 * It change the calibration gain setting  method which will need testing to verify that it still works.