### PR TITLE
Setting and getting badants

### DIFF
--- a/mnc/anthealth.py
+++ b/mnc/anthealth.py
@@ -10,11 +10,16 @@ ls = dsa_store.DsaStore()
 METHODS = ['selfcorr', 'union_and', 'union_or']
 
 
-def set_badants(method, antstatus, full=False, numbering='antnum'):
-    """ Set the list of bad antennas for a given badant method.
-    If providing status for all 352 antennas, use full=True.
+def set_badants(method, badants, numbering='antnum'):
+    """ Set the antenna status for a given badant method.
+    badants should be a list of integers of bad antannas.
     numbering defines antenna sequence and can be "antnum" (e.g., number in "LWA-001") or "correlator" (i.e., MS/CASA number).
+    Numbering in etcd is in antnum order, but values can be set/get in either convention.
     """
+
+    assert isinstance(badants, list), "badants must be a list"
+    assert isinstance(badants[0], int), "badants must hold ints"
+    assert numbering in ['antnum', 'correlator'], "numbering must be 'antnum' or 'correlator'"
 
     if method not in METHODS:
         logger.warning(f"method {method} is new. Add it to the fully supported list once validated: {METHODS}.")
@@ -23,33 +28,53 @@ def set_badants(method, antstatus, full=False, numbering='antnum'):
             logger.error("Cannot set antenna status with 'union'.")
             raise RuntimeError
 
+    if numbering is "correlator":
+        logger.debug("mapping correlator number to antnum")
+        badants2 = []
+        for corrnum in badants:
+            badants2.append(mapping.correlator_to_antname(corrnum).lstrip('LWA-'))
+        badants = badants2
+
+    antstatus = [a in badants for a in range(352)]  # make list of status for all ants in antnum order
+
     mjd = Time.now().mjd
-    if not full:
-        antstatus = [a in antstatus for a in range(352)]
-
     dd = {'time': mjd, 'flagged': antstatus}  # this could be expanded beyond booleans
-    ls.set_dict(f'/mon/anthealth/{method}', dd)
+    ls.put_dict(f'/mon/anthealth/{method}', dd)
 
 
-def get_badants(method, full=False, numbering='antnum'):
-    """ Given a badant method, return list of bad antennas 
-    If full ordered list of 352 antennas required, set "full=True".
+def get_badants(method, numbering='antnum'):
+    """ Given a badant method, return list of bad antennas
     numbering defines antenna sequence and can be "antnum" (e.g., number in "LWA-001") or "correlator" (i.e., MS/CASA number).
+    Numbering in etcd is in antnum order, but values can be set/get in either convention.
     """
+
+    assert numbering in ['antnum', 'correlator'], "numbering must be 'antnum' or 'correlator'"
 
     if method not in METHODS:
         logger.warning(f"method {method} is experimental. Fully suppoted methods: {METHODS}.")
 
     if 'union' not in method:
         dd = ls.get_dict(f'/mon/anthealth/{method}')
-        if not full:
-            return np.where(dd['flagged'])
-        else:
-            return dd['flagged']
-
-    if method == 'union_and':
+        antstatus = dd['flagged']
+    elif method == 'union_and':
         # iterate over methods and take logical and per ant
-        pass
+        # antstatus = ...
+        raise NotImplementedError
     elif method == 'union_or':
         # iterate over methods and take logical or per ant
-        pass
+        # antstatus = ...
+        raise NotImplementedError
+    else:
+        logger.warning(f"method {method} not recognized")
+
+    badants = np.where(antstatus)[0].tolist()
+        
+    if numbering is "correlator":
+        logger.debug("mapping antnum to correlator")
+        badants2 = []
+        for antnum in badants:
+            badants2.append(mapping.antname_to_correlator(f'LWA-{antnum}'))
+        badants = badants2
+
+    return badants
+

--- a/mnc/anthealth.py
+++ b/mnc/anthealth.py
@@ -10,16 +10,16 @@ ls = dsa_store.DsaStore()
 METHODS = ['selfcorr', 'union_and', 'union_or']
 
 
-def set_badants(method, badants, numbering='antnum'):
+def set_badants(method, badants, naming='ant'):
     """ Set the antenna status for a given badant method.
-    badants should be a list of integers of bad antannas.
-    numbering defines antenna sequence and can be "antnum" (e.g., number in "LWA-001") or "correlator" (i.e., MS/CASA number).
-    Numbering in etcd is in antnum order, but values can be set/get in either convention.
+    badants should be a list of antenna names as strings "001A" or "100". If no A/B pol, given then both pols assumed bad.
+    naming defines antenna sequence and can be "antnum" (e.g., number in "LWA-001").
     """
 
+    assert naming == 'ant', 'setting by ant naming only supported currently'
     assert isinstance(badants, list), "badants must be a list"
-    assert isinstance(badants[0], int), "badants must hold ints"
-    assert numbering in ['antnum', 'correlator'], "numbering must be 'antnum' or 'correlator'"
+    assert isinstance(badants[0], str), "badant entries must be str"
+    assert 'x' not in badants[0].lower() and 'y' not in badants[0].lower(), "define polarization with 'A' or 'B'"
 
     if method not in METHODS:
         logger.warning(f"method {method} is new. Add it to the fully supported list once validated: {METHODS}.")
@@ -28,27 +28,40 @@ def set_badants(method, badants, numbering='antnum'):
             logger.error("Cannot set antenna status with 'union'.")
             raise RuntimeError
 
-    if numbering is "correlator":
-        logger.debug("mapping correlator number to antnum")
-        badants2 = []
-        for corrnum in badants:
-            badants2.append(mapping.correlator_to_antname(corrnum).lstrip('LWA-'))
-        badants = badants2
+    # clean input badant list
+    badants2 = []
+    for badant in badants:
+        assert isinstance(badant, str)
 
-    antstatus = [a in badants for a in range(352)]  # make list of status for all ants in antnum order
+        if badant[-1] not in ['A', 'B']:
+            needspol = True
+        else:
+            needspol = False
 
+        if needspol:
+            aa = int(badant)
+            badants2.append(f'{aa:03}A')
+            badants2.append(f'{aa:03}B')
+        elif not needspol:
+            aa = int(badant[:-1])
+            pp = badant[-1]
+            badants2.append(f'{aa:03}{pp}')
+    badants = badants2
+
+    antnames, antstatus = zip(*[(a.lstrip('LWA-')+pol, a.lstrip('LWA-')+pol in badants) for a in mapping.filter_df('used', True).index for pol in ['A', 'B']])  # make list of status for all ants in antnum order
+    
     mjd = Time.now().mjd
-    dd = {'time': mjd, 'flagged': antstatus}  # this could be expanded beyond booleans
+    dd = {'time': mjd, 'flagged': antstatus, 'antname': antnames, 'naming': 'ant'}  # this could be expanded beyond booleans
     ls.put_dict(f'/mon/anthealth/{method}', dd)
 
 
-def get_badants(method, numbering='antnum'):
+def get_badants(method, naming='ant'):
     """ Given a badant method, return list of bad antennas
-    numbering defines antenna sequence and can be "antnum" (e.g., number in "LWA-001") or "correlator" (i.e., MS/CASA number).
-    Numbering in etcd is in antnum order, but values can be set/get in either convention.
+    naming defines antenna sequence and can be "ant" (e.g., number in "LWA-001") or "corr" (i.e., MS/CASA number).
+    Naming in etcd is in ant, but values can be set/get in either convention.
     """
 
-    assert numbering in ['antnum', 'correlator'], "numbering must be 'antnum' or 'correlator'"
+    assert naming in ['ant', 'corr'], "naming must be 'ant' or 'corr'"
 
     if method not in METHODS:
         logger.warning(f"method {method} is experimental. Fully suppoted methods: {METHODS}.")
@@ -56,6 +69,7 @@ def get_badants(method, numbering='antnum'):
     if 'union' not in method:
         dd = ls.get_dict(f'/mon/anthealth/{method}')
         antstatus = dd['flagged']
+        antnames = dd['antname']
     elif method == 'union_and':
         # iterate over methods and take logical and per ant
         # antstatus = ...
@@ -67,14 +81,19 @@ def get_badants(method, numbering='antnum'):
     else:
         logger.warning(f"method {method} not recognized")
 
-    badants = np.where(antstatus)[0].tolist()
-        
-    if numbering is "correlator":
-        logger.debug("mapping antnum to correlator")
+    badants = np.array(antnames)[np.where(antstatus)].tolist()
+
+    if naming is "corr":
+        logger.debug("mapping ant to corr naming")
         badants2 = []
-        for antnum in badants:
-            badants2.append(mapping.antname_to_correlator(f'LWA-{antnum}'))
+        for antname in badants:
+            antnum = antname[:-1]
+            pol = antname[-1]
+            badants2.append(str(mapping.antname_to_correlator(f'LWA-{antnum}'))+pol)
         badants = badants2
+
+    if -1 in badants:
+        logger.warning("Correlator number could not be found for some antennas. Something's fishy...")
 
     return badants
 

--- a/mnc/anthealth.py
+++ b/mnc/anthealth.py
@@ -1,0 +1,55 @@
+from dsautils import dsa_store
+from lwa_antpos import mapping
+from mnc import common
+from astropy.time import Time
+import numpy as np
+
+logger = common.get_logger(__name__)
+ls = dsa_store.DsaStore()
+
+METHODS = ['selfcorr', 'union_and', 'union_or']
+
+
+def set_badants(method, antstatus, full=False, numbering='antnum'):
+    """ Set the list of bad antennas for a given badant method.
+    If providing status for all 352 antennas, use full=True.
+    numbering defines antenna sequence and can be "antnum" (e.g., number in "LWA-001") or "correlator" (i.e., MS/CASA number).
+    """
+
+    if method not in METHODS:
+        logger.warning(f"method {method} is new. Add it to the fully supported list once validated: {METHODS}.")
+    else:
+        if 'union' in method.lower():
+            logger.error("Cannot set antenna status with 'union'.")
+            raise RuntimeError
+
+    mjd = Time.now().mjd
+    if not full:
+        antstatus = [a in antstatus for a in range(352)]
+
+    dd = {'time': mjd, 'flagged': antstatus}  # this could be expanded beyond booleans
+    ls.set_dict(f'/mon/anthealth/{method}', dd)
+
+
+def get_badants(method, full=False, numbering='antnum'):
+    """ Given a badant method, return list of bad antennas 
+    If full ordered list of 352 antennas required, set "full=True".
+    numbering defines antenna sequence and can be "antnum" (e.g., number in "LWA-001") or "correlator" (i.e., MS/CASA number).
+    """
+
+    if method not in METHODS:
+        logger.warning(f"method {method} is experimental. Fully suppoted methods: {METHODS}.")
+
+    if 'union' not in method:
+        dd = ls.get_dict(f'/mon/anthealth/{method}')
+        if not full:
+            return np.where(dd['flagged'])
+        else:
+            return dd['flagged']
+
+    if method == 'union_and':
+        # iterate over methods and take logical and per ant
+        pass
+    elif method == 'union_or':
+        # iterate over methods and take logical or per ant
+        pass

--- a/mnc/xengine_beamformer_control.py
+++ b/mnc/xengine_beamformer_control.py
@@ -248,7 +248,6 @@ class BeamPointingControl(object):
         # Load in the calibration data and normalize it
         tab = tables.table(caltable, ack=False)
         caldata = tab.getcol('CPARAM')[...]
-        caldata /= numpy.abs(caldata)
         
         # Load in the flagging data for the calibration
         flgdata = tab.getcol('FLAG')[...]


### PR DESCRIPTION
New module to support setting and getting of a list of bad antennas. It should be extensible to using any method people like or combinations thereof. I initialized with a small set of bad ants from Andrea's selfcorr analysis.

Here are some answer to @yupinghuang from [issue 467](https://github.com/ovro-lwa/lwa-issues/issues/467).
- I'll use a single key to hold the payload as you suggest (array of 352 bools). 
- The set/get can use antnum or correlator number all values mapped internally to antnum via `lwa-antpos`.
- Flags can be set with a method name (e.g., "selfcorr"). I've stubbed out code for "logical_and" and "logical_or" methods. We can expand that, if useful.
- Bad antennas can be made good again if the analysis method includes data from all ants (e.g., the selfcorr technique with f-engine data). I agree that using flagtables exclusively could get antennas permanently removed from the array.
- Retrospective flagging/health checks would rely on influx. I've always been a bit unclear on how to design for that. @rh-codebase: we're setting up an etcd payload structured like this: `{'time': mjd, 'flagged': [array of 352 bools]}`. We'd like to use influx/grafana to answer questions like "which antennas are bad at time x?" and "what did this antenna look like for the last month". Any suggestions on etcd/influx design?