### PR TITLE
beamformer antenna selection should normalize correctly

### DIFF
--- a/mnc/settings.py
+++ b/mnc/settings.py
@@ -53,7 +53,18 @@ class Settings():
         """ Read configuration data file """
 
         self.filename = filename
-        if filename is not None:
+        self.read_settings(filename=filename)
+
+    def read_settings(self, filename=None, filenum=None):
+        """ Reads a settings file defined by full path or a time-sorted index (use list_settings to print them in order)
+        if filename is defined, it will be used.
+        """
+
+        if filenum is not None and filename is None:
+            filename = sorted([(fn, os.path.basename(fn).split('-')[0]) for fn in glob.glob(DATAPATH + '/*mat')], key=lambda x: x[1])[filenum][0]
+            self.filename = filename
+
+        if self.filename is not None:
             self.config = mat.loadmat(self.filename, squeeze_me=True)
             print('Read data file', self.filename)
             print('Data file internal time: ',time.asctime(time.gmtime(self.config['time'])))
@@ -61,6 +72,24 @@ class Settings():
         else:
 #            self.config = <read from etcd>
             pass
+
+    def list_settings(self):
+        """ Show time ordered list of settings files.
+        
+        """
+
+        enl = enumerate(sorted([(fn, os.path.basename(fn).split('-')[0]) for fn in glob.glob(DATAPATH + '/*mat')], key=lambda x: x[1]))
+        for j,k in enl:
+            print(f'{j}: {k[0]}')
+
+    def get_last_settings(self, path='/home/pipeline/proj/lwa-shell/mnc_python/data/'):
+        """ Look at standard log file and read last entry.
+        """
+
+        # TODO: use etcd for this
+
+        with open(path+'arxAndF-settings.log','r') as f:
+            return os.path.join(DATAPATH, f.readlines()[-1].split()[-2])
 
     def load_feng(self):
         """ Load settings for f-engine to the SNAP2 boards.

--- a/mnc/xengine_beamformer_control.py
+++ b/mnc/xengine_beamformer_control.py
@@ -156,7 +156,7 @@ class BeamPointingControl(object):
         self._gain = 1.0
         
         # Initially set uniform antenna weighting for a natural beam shape
-        self.set_beam_weighting(lambda x: 1.0)
+        self.set_beam_weighting(fnc=lambda x: 1.0)
         
     def __repr__(self):
         n = self.__class__.__module__+'.'+self.__class__.__name__

--- a/mnc/xengine_beamformer_control.py
+++ b/mnc/xengine_beamformer_control.py
@@ -248,6 +248,7 @@ class BeamPointingControl(object):
         # Load in the calibration data and normalize it
         tab = tables.table(caltable, ack=False)
         caldata = tab.getcol('CPARAM')[...]
+        caldata /= numpy.abs(caldata)
         
         # Load in the flagging data for the calibration
         flgdata = tab.getcol('FLAG')[...]


### PR DESCRIPTION
flag_ants argument controls antennas to be removed during beamforming.
Note that calibration gains are self-normalized and still use caltable flags. That is not the recommended way of flagging whole antennas (only bad solutions for ant-pol-spw).