### PR TITLE
Address https://github.com/ovro-lwa/lwa-issues/issues/486#issuecommen…

### DIFF
--- a/mnc/control.py
+++ b/mnc/control.py
@@ -415,11 +415,11 @@ class Controller():
         fast_vis_n = 0
         for corridn_a, corrid_a in enumerate(fast_corrids):
             for corridn_b, corrid_b in enumerate(fast_corrids[corridn_a:]):
-                # Add all 4 polarization products
+                # Add all 4 polarization products -- must match the order expected by the data recorder.
                 fast_vis_out[fast_vis_n+0] = [[corrid_a, 0], [corrid_b, 0]]
                 fast_vis_out[fast_vis_n+1] = [[corrid_a, 0], [corrid_b, 1]]
-                fast_vis_out[fast_vis_n+2] = [[corrid_a, 1], [corrid_b, 1]]
-                fast_vis_out[fast_vis_n+3] = [[corrid_a, 1], [corrid_b, 0]]
+                fast_vis_out[fast_vis_n+2] = [[corrid_a, 1], [corrid_b, 0]]
+                fast_vis_out[fast_vis_n+3] = [[corrid_a, 1], [corrid_b, 1]]
                 fast_vis_n += 4
         for i in range(self.npipeline*self.nhosts):
             self.pcontroller.pipelines[i].corr_subsel.set_baseline_select(fast_vis_out)


### PR DESCRIPTION
…t-1927325521

The X-engine baseline selection happens on a per-polarization level - i.e. it is possible to select baselines of arbitrary polarization, e.g. all XX pols. The fast correlator output has two packet formats, one allows arbitrary selection while the other is COR-standard and assumes that each packet contains data from all 4 polarization-products of a station pair.
If using this output format (which the LWA-OVRO correlator typically does) the baselines selected are assumed to be in sets of 4 where each 4 consecutive baselines are the 4 pol-pairs of a single station pair. In this case, the 4 baselines selected must match the polarization order expeted by the COR format.