### PR TITLE
Larry's pull request

### DIFF
--- a/mnc/myarx.py
+++ b/mnc/myarx.py
@@ -1,4 +1,3 @@
-# myarx.py ARX control/monitor using raw()
 # 20220112 - add functions 'gainAdjust', 'filterSelect'.
 # 20220310 - add rfPowerSave().
 # 20221014 - revise status_asig() not to get rfPowerOffset if provided by caller.
@@ -10,7 +9,7 @@
 # 20230628 - feeOn(), feeOff():  add option to control a single channel.
 # 20230809 - fix bugs in feeOn() and feeOff() for single-channel control.
 # 20231114 - fix bug in status() when offsets not given.
-
+# 20240307 - Remove obsolete code lines.  Use opsdatapath.py for log file.
 
 import lwautils.lwa_arx
 import sys
@@ -18,17 +17,18 @@ import numpy as np
 import math as m
 import time
 import warnings
-from mnc import common
-
-logger = common.get_logger(__name__)
 
 arx = lwautils.lwa_arx.ARX()
 
-adrs = range(15,46)  #addresses of ARX boards (rollout phase 3)
-RFPOWEROFFSETLOG = '/home/ldaddario/arxPowerOffsets.log'
+import opsdatapath
+RFPOWEROFFSETLOG = opsdatapath.OPSDATAPATH + 'arxPowerOffsets.log'
 
 def raw(adr,cmd):
-    r = arx.raw(adr,cmd)
+    r = []
+    try:
+        r = arx.raw(adr,cmd)
+    except:
+        pass
     return r
 
 def raw2int(adr,cmd):

--- a/mnc/opsdatapath.py
+++ b/mnc/opsdatapath.py
@@ -1,0 +1,8 @@
+#!/var/bin python
+# Define path to directory containing useful data for LWA operation
+
+# 20240228  Initial version
+# 20240307  Assign path to ~pipeline/opsdata.
+
+OPSDATAPATH = '/home/pipeline/opsdata/'
+

--- a/mnc/sigtab.py
+++ b/mnc/sigtab.py
@@ -1,0 +1,55 @@
+#!/var/bin python
+# LWA signal number conversion module
+# Convert among digital signal number (dsig), analog signal number (asig),
+# antenna name, and SNAP2 or ARX board.
+
+# 20230601  Initial version.
+# 20230627  Fix bug in name2sig if name not found.
+# 20240228  Use opsdatapath.py to find sigtab.mat
+
+import scipy.io as mat
+import opsdatapath as dp
+
+d = mat.loadmat(dp.OPSDATAPATH+'sigtab.mat')
+sigtab = d['sigtab']
+antNames = d['antNames']
+
+def d2a(dsig):   # dsig to asig
+    return(sigtab[dsig][0])
+
+def a2d(asig):   # asig to dsig
+    for i in range(len(sigtab)):
+        if sigtab[i][0]==asig:
+            return(sigtab[i][1])
+    return(None)
+
+def d2name(dsig):# dsig to antenna name
+    return(antNames[dsig])
+
+def a2name(asig):# asig to antenna name
+    for i in range(len(sigtab)):
+        if sigtab[i][0]==asig:
+            return(antNames[i])
+    return(None)
+
+def d2feng(dsig):# dsig to SNAP2 id and SNAP2 signal number
+    snap = int(dsig/64) + 1
+    sig = dsig % 64
+    return(snap,sig)
+
+def a2arx(asig): # asig to ARX address and ARX channel number
+    adr = int(asig/16)
+    chan = asig - 16*adr + 1  # channel number is 1-based
+    adr += 1                  # address is 1-based
+    return(adr,chan)
+
+def name2sig(name):
+    i=0
+    while i<len(antNames):
+        if antNames[i]==name:
+            break
+        i = i+1
+    if i<len(antNames):
+        return(sigtab[i])
+    else:
+        return(None)


### PR DESCRIPTION
Add new files:
./mnc/opsdatapath.py     # provides variable OPSDATAPATH assigned to '/home/pipeline/opsdata'
./mnc/sigtab.py               # module with functions for determining any signal path ("mapping").  

Documentation for sigtab is in the memo "LWA Signal Bookkeeping Software" of 2023 March 05.  It is based on concepts described in the earlier memo "Signal Bookkeeping for LWA352" of 2022 March 3.

The sigtab module depends on the opsdatapath module to find data file 'sigtab.mat', which contains a simple table giving all signal paths.

Update:
./mnc/myarx.py               # delete unused code lines; use opsdatapath to find 'arxPowerOffsets.log' file.
