### PR TITLE
Fix engine configuration updates

### DIFF
--- a/mnc/control.py
+++ b/mnc/control.py
@@ -18,7 +18,7 @@ try:
 except ImportError:
     logger.warning('No f-eng library found. Skipping.')
 try:
-    from lwa352_pipeline_control import Lwa352CorrelatorControl, BeamPointingControl  # xengine
+    from lwa352_pipeline_control import Lwa352CorrelatorControl  # xengine
 except ImportError:
     logger.warning('No x-eng library found. Skipping.')
 

--- a/mnc/settings.py
+++ b/mnc/settings.py
@@ -140,9 +140,7 @@ class Settings():
         if len(pfb_shift) != 11 or not all(pfb_shift.values()):
             logger.warning('Not all SNAPs set to FFT shift. Check logs.')
             return False
-        else:
-            logger.info('All SNAPs set to FFT shift.')
-            return True
+        logger.info('All SNAPs set to FFT shift.')
 
         #=====================================
         # LOAD F ENGINE EQUALIZATION FUNCTIONS
@@ -281,6 +279,8 @@ class Settings():
                 address, channel = mapping.antpol_to_arx(antname, pol)
                 a.feeOff(address, channel)
             print('Turned off',len(off),'signals: dsig=',off)        
+
+        return True
 
 
     def load_arx(self):


### PR DESCRIPTION
  - Remove the obsolete `BeamPointingControl` import from
    `lwa352_pipeline_control`.
  - Allow `Settings.load_feng()` to continue loading equalization coefficients,
    delays, and unused-input settings after verifying the FFT shift.
  - Return success only after the complete F-engine settings operation finishes.

  ## Root cause

  The installed `lwa352_pipeline_control` package exports
  `Lwa352CorrelatorControl` but not `BeamPointingControl`. Importing both names in
  one statement caused the entire X-engine import to fail, resulting in the
  misleading warning:

  `No x-eng library found. Skipping.`

  Commit `531ad35` also introduced an early `return True` immediately after the
  F-engine FFT-shift check. This made the EQ, delay, and unused-input sections
  unreachable while allowing `settings.update()` to report and log success.